### PR TITLE
Handled a strange case where OTX provides empty links in their pulses.

### DIFF
--- a/src/otx_misp/__init__.py
+++ b/src/otx_misp/__init__.py
@@ -191,7 +191,7 @@ def create_events(pulse_or_list, author=False, server=False, key=False, misp=Fal
     if 'references' in pulse:
         for reference in pulse['references']:
             log.info("\t - Adding external analysis link: {}".format(reference))
-            if misp:
+            if misp and reference:
                 misp.add_named_attribute(event, 'link', reference, category='External analysis')
             result_event['attributes']['references'].append(reference)
 


### PR DESCRIPTION
Don't know why, under some circumstances, OTX provides empty reference links in their pulses. 

I have just modified the import script to handle this specific situation. 