### PR TITLE
Fixed the PyMISP version check

### DIFF
--- a/src/otx_misp/__init__.py
+++ b/src/otx_misp/__init__.py
@@ -77,7 +77,7 @@ def tag_event(misp, event, tag):
         for a, b in zip(version, tag_version):
             if a == b:
                 continue
-            elif a > b:
+            elif int(a) > int(b):
                 continue
             else:  # a < b
                 misp.add_tag(event, tag)


### PR DESCRIPTION
Fixed the PyMISP version check: a string comparison was used instead of an int comparison. This was not causing any issue before PyMISP version 100.