### PR TITLE
Fix search issue with author and dedup_titles both selected

### DIFF
--- a/src/otx_misp/__init__.py
+++ b/src/otx_misp/__init__.py
@@ -266,7 +266,8 @@ def create_events(pulse_or_list, author=False, server=False, key=False, misp=Fal
                 event_name = pulse['name']
 
             # Search MISP for the title
-            result = misp.search_index(eventinfo=event_name)
+            search_term = event_name.replace("|","\|")
+            result = misp.search_index(eventinfo=search_term)
             if 'message' in result:
                 if result['message'] == "No matches.":
                     event = misp.new_event(distribution, threat_level, analysis, event_name, date=event_date,


### PR DESCRIPTION
There's an odd issue with PyMISP's search_index() function where it either truncates the search term at | or treats | as an OR statement. 

Either way, if you have a large DB filled with stuff like "Alienvault | Pulse Name" you'll get back results for every event that has Alienvault in the title. That is, unless you changing the | to \| right before searching, which is what this PR does.