### PR TITLE
Reworked the whole code for being compatible with latest PyMISP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'Alienvault', 'OTX', 'MISP'
     ],
     install_requires=[
-        'pymisp>=2.4.53',
+        'pymisp>=2.4.113',
         'python-dateutil'
     ],
     extras_require={

--- a/src/otx_misp/otx/OTXv2.py
+++ b/src/otx_misp/otx/OTXv2.py
@@ -5,7 +5,7 @@ import logging
 
 from . import IndicatorTypes
 
-API_V1_ROOT = "{}/api/v1/"
+API_V1_ROOT = "{}/api/v1"
 PULSES_ROOT = "{}/pulses".format(API_V1_ROOT)
 SUBSCRIBED = "{}/subscribed".format(PULSES_ROOT)
 EVENTS = "{}/events".format(PULSES_ROOT)


### PR DESCRIPTION
Reworked the whole code for being compatible with latest PyMISP >= 2.4.113.

It has not been easily possible to keep compatibility with older versions.

But the code has a few more improvements:
- Only fetch the list of available MISP tags once
- Fixed the check for existing MISP tag: a MISP tag is only added if it is not already present in the MISP event. 
- The same has been done at the attribute level to prevent PyMISP from generating errors. This part can even be optimized by doing all the stuff in memory. For the moment, a request is made to MISP to search for an existing similar attribute. 